### PR TITLE
Add diff visualization helper

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,8 @@ JSONDiff = new path.to.the.cfc.JSONDiff(); //Instantiate Object
 JSONDiff.diff(origData, newData [, ignored array of keys])
 JSONDiff.diffByKey(origData, newData, uniqueKey [, ignored array of keys])
 JSONDiff.isSame(origData, newData [, ignored array of keys])
+JSONDiff.summary(diffs)
+JSONDiff.visualizeDiff(origData, newData [, ignored array of keys])
 ```
 
 ## Usage
@@ -139,6 +141,32 @@ Great for comparing 2 arrays of structs
 
     //Result
     false
+```
+
+### summary (diffs)
+#### Get a count of each diff type.
+
+```javascript
+    var diffs = JSONDiff.diff({a:1},{a:2,b:3});
+    JSONDiff.summary(diffs);
+
+    //Result
+    {
+        add: 1,
+        remove: 0,
+        change: 1,
+        update: 0
+    }
+```
+
+### visualizeDiff (origData, newData [, ignored array of keys])
+#### Return a simple HTML diff between two objects.
+
+```javascript
+    JSONDiff.visualizeDiff({a:1},{a:2});
+
+    //Result
+    <ul><li><span style="font-weight:bold">a</span>: <span style="background: #ffbbbb;text-decoration: line-through;">1</span> <span style="background: #bbffbb;">2</span></li></ul>
 ```
 
 ## License

--- a/models/jsondiff.cfc
+++ b/models/jsondiff.cfc
@@ -322,6 +322,14 @@ component singleton {
         return arrayToList(diffToHTML(diffPatchObj), '');
     }
 
+    /**
+    * Generate an HTML visualization of the differences between two objects.
+    */
+    function visualizeDiff(required any first, required any second, array ignoreKeys = []) {
+        var diffs = diff(arguments.first, arguments.second, arguments.ignoreKeys);
+        return displayDiff(arguments.first, diffs);
+    }
+
     function diffToHTML(required diffPatchObj, nodes = []) {
         var diffPatchObj = duplicate(arguments.diffPatchObj);
         if (isArray(diffPatchObj)) {
@@ -357,6 +365,22 @@ component singleton {
             }
         }
         return nodes;
+    }
+
+    function summary(required any diffs) {
+        var counts = { 'add': 0, 'remove': 0, 'change': 0, 'update': 0 };
+        if (isArray(diffs)) {
+            for (var i = 1; i <= diffs.len(); i++) {
+                var typeKey = lcase(diffs[i].type);
+                if (!counts.keyExists(typeKey)) counts[typeKey] = 0;
+                counts[typeKey]++;
+            }
+        } else if (isStruct(diffs)) {
+            for (var key in ['add','remove','change','update']) {
+                if (diffs.keyExists(key)) counts[key] = arrayLen(diffs[key]);
+            }
+        }
+        return counts;
     }
 
     function diffpatch(required original, diff = []) {

--- a/tests/specs/integration/SummarySpec.cfc
+++ b/tests/specs/integration/SummarySpec.cfc
@@ -1,0 +1,22 @@
+/**
+* Tests for the summary method
+*/
+component extends="testbox.system.BaseSpec"{
+        function beforeAll(){
+                jsondiff = new models.jsondiff();
+        }
+
+        function run(){
+                describe("Test Summary", ()=>{
+                        it("counts diff types", ()=>{
+                                var diffs = jsondiff.diff({a:1},{a:2,b:3});
+                                expect(jsondiff.summary(diffs)).toBe({
+                                        add:1,
+                                        remove:0,
+                                        change:1,
+                                        update:0
+                                });
+                        });
+                });
+        }
+}

--- a/tests/specs/integration/VisualizeSpec.cfc
+++ b/tests/specs/integration/VisualizeSpec.cfc
@@ -1,0 +1,17 @@
+/**
+* Tests for the visualizeDiff method
+*/
+component extends="testbox.system.BaseSpec"{
+    function beforeAll(){
+        jsondiff = new models.jsondiff();
+    }
+
+    function run(){
+        describe("Test VisualizeDiff", ()=>{
+            it("outputs html", ()=>{
+                var html = jsondiff.visualizeDiff({a:1},{a:2});
+                expect(html).toBe('<ul><li><span style="font-weight:bold">a</span>: <span style="background: #ffbbbb;text-decoration: line-through;">1</span> <span style="background: #bbffbb;">2</span></li></ul>');
+            });
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- implement `visualizeDiff` to produce HTML output for diffs
- document HTML visualization in README
- test visualizeDiff functionality

## Testing
- `ant -f tests/test.xml run` *(fails: command not found)*
- `box testbox run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684077d983f8832ab1139e0017d9e124